### PR TITLE
Bugfix

### DIFF
--- a/rtl/CMA.vp
+++ b/rtl/CMA.vp
@@ -192,7 +192,7 @@ module `mname` (
    assign {denormA_P1, denormC} = {ZeroExpA_P1, ZeroExpC};
    
 //; } else {
-  assign {denormA_P1, demormC} = 0;
+   assign {denormA_P1, denormC} = 0;
 //; }
 
 //; my $pipe_A1_depth = ($enable_forwarding eq 'YES') ? 1 : 0;

--- a/rtl/FarPathAdd.vp
+++ b/rtl/FarPathAdd.vp
@@ -215,6 +215,7 @@ assign smallerFraction_P2   = subtract_P2 ? ~shift_out_P2 : shift_out_P2;
                                .valid_in(valid_P2), .clk(clk) , .stall(stall), .reset(reset), 
                                .out({ExtendedExpSum_P3, ManB_overnormal_P3, sumUpper_P3, sumMiddleSticky_P3, RSticky_P3, SignSum_out, ZeroSum_out }),
                                .valid_out(valid_P3) );
+   assign valid_out = valid_P3;
    //; } else {
    assign {ExtendedExpSum_P3, ManB_overnormal_P3, sumUpper_P3, sumMiddleSticky_P3, RSticky_P3, SignSum_out, ZeroSum_out } = {ExtendedExpSum_P2, ManB_overnormal_P2, sumUpper_P2, sumMiddleSticky_P2, RSticky_P2, SignSum_P2, ZeroSum_P2  };
    //; }


### PR DESCRIPTION
Found and fixed a couple of obvious bugs. I think they exist because they only surface when the denorm-support option is turned OFF for CMA, and maybe that wasn't tested so well previously. Anyway, it works now and has been tested up through tapeout in librelane. TODO maybe should add an action to test the denorm-off path?