### PR TITLE
Ripple-adder problems

### DIFF
--- a/rtl/Multiplier.vp
+++ b/rtl/Multiplier.vp
@@ -41,8 +41,9 @@
 //;                                 "Possible values are ON or Off. !IGNORE! ");
 //;
 //; # get some values from the top
-//; my $verif_mode = $self->get_top_param('VERIF_MODE'); # Reads this parameter from the top level
-//; my $synth_mode = $self->get_top_param('SYNTH_MODE'); # Reads this parameter from the top level
+//; # FIXME does this not just immediately rewrite the parameters above? Is that why they are marked IGNORE? What??
+//; $verif_mode = $self->get_top_param('VERIF_MODE'); # Reads this parameter from the top level
+//; $synth_mode = $self->get_top_param('SYNTH_MODE'); # Reads this parameter from the top level
 //;
 //; my $DW_mode = parameter(Name=>'Designware_MODE',
 //;                            Val=>'OFF', List=>['ON','OFF'],

--- a/rtl/adder.vp
+++ b/rtl/adder.vp
@@ -8,7 +8,7 @@
 //;
 //  PARAMETERS:
 //; my $AdderType = parameter( name=>'AdderType', val=>'DesignWare' ,
-//;                            doc=>'!implementation! AdderType: Topology for the Propogate Generate tree.  Ripple type indicates that a ripple chain should be used rather than a tree. Sklansky indicates that a sklansky topology should be used. Can also request to use the Designware default adder. Legal Values: Ripple Sklansky Designware !IMPLEMENTATION!' ,
+//;                            doc=>'!implementation! AdderType: Topology for the Propogate Generate tree.  Ripple type indicates that a ripple chain should be used rather than a tree. Can also request a sklansky topology, or can simply use a Designware default adder. Legal Values: Ripple Sklansky Designware !IMPLEMENTATION!' ,
 //;                            list=>[ 'Ripple' , 'Sklansky' , 'DesignWare' ] ) ;
 //; my $BW  = parameter( name=>'BitWidth', val=>16 , 
 //;                      doc=>'!functional! BitWidth of input and output values.  32 corresponds to a 32 bit signal A added to a 32 bit signal B  resulting in a 32 bit output S. Legal Values: Integers from 2 to 512  !FUNCTIONAL!' , 

--- a/rtl/adder.vp
+++ b/rtl/adder.vp
@@ -10,6 +10,9 @@
 //; my $AdderType = parameter( name=>'AdderType', val=>'DesignWare' ,
 //;                            doc=>'!implementation! AdderType: Topology for the Propogate Generate tree.  Ripple type indicates that a ripple chain should be used rather than a tree. Can also request a sklansky topology, or can simply use a Designware default adder. Legal Values: Ripple Sklansky Designware !IMPLEMENTATION!' ,
 //;                            list=>[ 'Ripple' , 'Sklansky' , 'DesignWare' ] ) ;
+//; # Oops
+//; $AdderType eq 'Ripple' and $self->error( "ERROR adder.vp: AdderType 'Ripple' is currently broken, sorry! Maybe try 'Sklansky' instead." ) ;
+//;
 //; my $BW  = parameter( name=>'BitWidth', val=>16 , 
 //;                      doc=>'!functional! BitWidth of input and output values.  32 corresponds to a 32 bit signal A added to a 32 bit signal B  resulting in a 32 bit output S. Legal Values: Integers from 2 to 512  !FUNCTIONAL!' , 
 //;                      min=>2 , max=>512, step=>1 );

--- a/rtl/adder.vp
+++ b/rtl/adder.vp
@@ -8,8 +8,8 @@
 //;
 //  PARAMETERS:
 //; my $AdderType = parameter( name=>'AdderType', val=>'DesignWare' ,
-//;                            doc=>'!implementation! AdderType: Indicate the topology to use for the Propogate Generate tree.  Ripple type indicates that a ripple chain should be used rather than a tree.  Sklansky indicates that a sklansky topology should be used (Weste&Harris 3rd pp662). Legal Values: Ripple Sklansky  !IMPLEMENTATION!' ,
-//;                            list=>[ 'Sklansky' , 'DesignWare' ] ) ;
+//;                            doc=>'!implementation! AdderType: Topology for the Propogate Generate tree.  Ripple type indicates that a ripple chain should be used rather than a tree. Sklansky indicates that a sklansky topology should be used. Can also request to use the Designware default adder. Legal Values: Ripple Sklansky Designware !IMPLEMENTATION!' ,
+//;                            list=>[ 'Ripple' , 'Sklansky' , 'DesignWare' ] ) ;
 //; my $BW  = parameter( name=>'BitWidth', val=>16 , 
 //;                      doc=>'!functional! BitWidth of input and output values.  32 corresponds to a 32 bit signal A added to a 32 bit signal B  resulting in a 32 bit output S. Legal Values: Integers from 2 to 512  !FUNCTIONAL!' , 
 //;                      min=>2 , max=>512, step=>1 );


### PR DESCRIPTION
### Problem
Ripple-adder exists as an option but is not well supported. For details see Issue <https://github.com/StanfordVLSI/FP-Gen/issues/9>.


### Solution
I added the ripple-adder option to the parameter list.

But upon testing it out, I found it to be pretty badly broken.

So I added a useful error message for anyone that tries to use it, and I am including those changes in this PR.

BUT. i feel like this is not resolved. If the ripple adder is truly unusable, that's a lot of useless code that could be eliminated maybe.

We should either fix the code or delete it!


